### PR TITLE
Use current directories when deploying the repository

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           gcp_workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           gcp_service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+          metadata_path: metadata
+          targets_path: targets
 
   deploy:
     permissions:

--- a/.github/workflows/version-bumps.yml
+++ b/.github/workflows/version-bumps.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           gcp_workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           gcp_service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+          metadata_path: metadata
+          targets_path: targets
 
   offline-version-bump:
     runs-on: ubuntu-latest


### PR DESCRIPTION
See https://github.com/jku/repository-playground/pull/125 for related details.

This PR updates the template with default values for the metadata and targets path, which are consistent with the current behaviour of repository playground.